### PR TITLE
Fix lightbox image covered by status bar

### DIFF
--- a/webroot/rsrc/css/aphront/lightbox-attachment.css
+++ b/webroot/rsrc/css/aphront/lightbox-attachment.css
@@ -17,7 +17,7 @@
 }
 
 .lightbox-attachment img {
-  margin: 3% auto 0;
+  margin: 3% auto 30px;
   max-height: 90%;
   max-width: 90%;
 }


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1073082/5431829/da8e1876-846b-11e4-903a-28aee9afee06.png)

After:
![image](https://cloud.githubusercontent.com/assets/1073082/5431827/cdaa8608-846b-11e4-8646-426c4625a5c3.png)
